### PR TITLE
scroll fix > removed overflow:hidden for mobile view

### DIFF
--- a/src/Components/Home/index.js
+++ b/src/Components/Home/index.js
@@ -39,7 +39,10 @@ function Home() {
   const { isMobile = false } = useContext(Context);
 
   return (
-    <div id="main_con" className={styles.container}>
+    <div
+      id="main_con"
+      className={isMobile ? styles.mobile_container : styles.container}
+    >
       <Header
         activeWindow={activeWindow}
         scrollToWithoutLag={scrollToWithoutLag}

--- a/src/Components/Home/styles.module.css
+++ b/src/Components/Home/styles.module.css
@@ -1,5 +1,10 @@
 .container {
   width: 100vw;
   height: 100vh;
-  overflow-y: hidden; /* //? just to hide scroll bar*/
+  overflow-y: hidden; /* to stop user from scrolling > and only scroll through function */
+}
+
+.mobile_container{
+  width: 100vw;
+  height: 100vh;
 }


### PR DESCRIPTION
overflow: hidden was added at Home to stop user from scrolling 
> and only scroll through function
but it also stopped user from scrolling in mobile view.
SO, just made a second class for mobile view.., resolved the issue
